### PR TITLE
Fix README command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Once configured, you can use the following commands in Claude Desktop:
 
 ### List Pages
 
-```
-growi_list_pages can you list all pages under the /projects path?
+```text
+mcp_growi_growi_list_pages can you list all pages under the /projects path?
 ```
 
-```
+```text
 /user のパスから10件取ってきて
 ```
 


### PR DESCRIPTION
## Summary
- specify `text` language for usage examples
- keep usage example with `mcp_growi_growi_list_pages`

## Testing
- `npm test` *(fails: jest not found)*