### PR TITLE
Improve CI build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,12 @@ jobs:
         with:
           node-version: 18
       - run: npm ci
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            ts:
+              - '**/*.ts'
+      - run: npm run build
+        if: steps.filter.outputs.ts == 'true'
       - run: npm test


### PR DESCRIPTION
## Summary
- update CI to skip build unless TypeScript files change

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm install` *(fails: `Exit handler never called!`)*